### PR TITLE
Fix data fetch error by proxying API requests

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/api` requests to the backend

## Testing
- `npm test` *(fails: could not find package.json in repository root)*

------
https://chatgpt.com/codex/tasks/task_e_686276e2762c8320b54ed8eb15256f8a