### PR TITLE
Remove login and adjust chart width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,10 @@
 # TradinAI2
 
-Esta aplicación contiene un backend en Node.js y un frontend en React para mostrar datos de mercado y autenticación con Google.
+Esta aplicación contiene un backend en Node.js y un frontend en React para mostrar datos de mercado.
 
 ## Variables de entorno
 
-Crea un archivo `.env` en la raíz del proyecto con los siguientes valores:
-
-```
-GOOGLE_CLIENT_ID=tu-client-id-de-google
-GOOGLE_CLIENT_SECRET=tu-client-secret-de-google
-```
-
-Para el frontend, también crea un archivo `frontend/.env` con:
-
-```
-VITE_GOOGLE_CLIENT_ID=tu-client-id-de-google
-```
-
-Reemplaza `tu-client-id-de-google` y `tu-client-secret-de-google` con las credenciales obtenidas desde la consola de Google Cloud.
+No se requiere autenticación ni configuración adicional.
 
 ## Instalación
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,9 +13,6 @@
   "dependencies": {
     "express": "^4.19.2",
     "cors": "^2.8.5",
-    "passport": "^0.7.0",
-    "passport-google-oauth20": "^2.0.0",
-    "express-session": "^1.17.3",
     "dotenv": "^16.3.1"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,6 @@
 const express = require('express');
 const cors = require('cors');
-const passport = require('passport');
-const session = require('express-session');
-const GoogleStrategy = require('passport-google-oauth20').Strategy;
+// Removed authentication dependencies
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
@@ -11,33 +9,6 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.use(session({ secret: 'secret', resave: false, saveUninitialized: true }));
-app.use(passport.initialize());
-app.use(passport.session());
-
-passport.serializeUser((user, done) => done(null, user));
-passport.deserializeUser((obj, done) => done(null, obj));
-
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || 'GOOGLE_CLIENT_ID';
-const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'GOOGLE_CLIENT_SECRET';
-
-passport.use(new GoogleStrategy({
-    clientID: GOOGLE_CLIENT_ID,
-    clientSecret: GOOGLE_CLIENT_SECRET,
-    callbackURL: '/auth/google/callback'
-  },
-  (accessToken, refreshToken, profile, done) => {
-    return done(null, profile);
-  }
-));
-
-app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
-app.get('/auth/google/callback',
-  passport.authenticate('google', { failureRedirect: '/' }),
-  (req, res) => {
-    res.redirect('/');
-  }
-);
 
 app.get('/api/data/:symbol', (req, res) => {
   const symbol = req.params.symbol.toLowerCase();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@react-oauth/google": "^0.8.0",
     "axios": "^1.6.8",
     "bootstrap": "^5.3.7",
     "lightweight-charts": "^4.2.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,6 @@
 #root {
-  max-width: 1280px;
+  width: 90vw;
+  max-width: none;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Chart from './Chart.jsx';
-import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
 
 export default function App() {
   const [symbol, setSymbol] = useState('aapl');
   const [data, setData] = useState([]);
   const [signals, setSignals] = useState([]);
-  const [user, setUser] = useState(null);
 
   const fetchData = async (sym) => {
     const d = await axios.get(`/api/data/${sym}`);
@@ -19,19 +17,15 @@ export default function App() {
   useEffect(() => { fetchData(symbol); }, [symbol]);
 
   return (
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
-      <div className="container-fluid p-3">
-        {user ? (
-          <p>Bienvenido {user.name}</p>
-        ) : (
-          <GoogleLogin onSuccess={() => setUser({ name: 'Usuario Google' })} onError={() => alert('Error')} />
-        )}
-        <select className="form-select my-3" value={symbol} onChange={e => setSymbol(e.target.value)}>
-          <option value="aapl">AAPL</option>
-          <option value="goog">GOOG</option>
-        </select>
-        <Chart data={data} signals={signals} />
-      </div>
-    </GoogleOAuthProvider>
+    <div className="container-fluid p-3">
+      <input
+        type="text"
+        className="form-control my-3"
+        value={symbol}
+        onChange={e => setSymbol(e.target.value.toLowerCase())}
+        placeholder="Símbolo (ej. AAPL)"
+      />
+      <Chart data={data} signals={signals} />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop Google login from backend and frontend
- shrink dependencies accordingly
- widen root container to 90vw
- allow custom symbol input
- update README

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `node backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68628a00559c8320a84503d8a9055b58