### PR TITLE
Fix asset selection

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,14 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+app.get('/api/symbols', (req, res) => {
+  const files = fs.readdirSync(path.join(__dirname, 'data'));
+  const symbols = files
+    .filter(f => f.endsWith('.json'))
+    .map(f => path.basename(f, '.json'));
+  res.json(symbols);
+});
+
 
 app.get('/api/data/:symbol', (req, res) => {
   const symbol = req.params.symbol.toLowerCase();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,25 +6,43 @@ export default function App() {
   const [symbol, setSymbol] = useState('aapl');
   const [data, setData] = useState([]);
   const [signals, setSignals] = useState([]);
+  const [symbolsList, setSymbolsList] = useState([]);
 
   const fetchData = async (sym) => {
-    const d = await axios.get(`/api/data/${sym}`);
-    setData(d.data);
-    const s = await axios.get(`/api/signals/${sym}`);
-    setSignals(s.data);
+    try {
+      const d = await axios.get(`/api/data/${sym}`);
+      setData(d.data);
+      const s = await axios.get(`/api/signals/${sym}`);
+      setSignals(s.data);
+    } catch (err) {
+      setData([]);
+      setSignals([]);
+    }
   };
 
   useEffect(() => { fetchData(symbol); }, [symbol]);
 
+  useEffect(() => {
+    axios.get('/api/symbols')
+      .then(res => setSymbolsList(res.data))
+      .catch(() => setSymbolsList([]));
+  }, []);
+
   return (
     <div className="container-fluid p-3">
       <input
+        list="symbols"
         type="text"
         className="form-control my-3"
         value={symbol}
-        onChange={e => setSymbol(e.target.value.toLowerCase())}
-        placeholder="Símbolo (ej. AAPL)"
+        onChange={e => setSymbol(e.target.value.toLowerCase().trim())}
+        placeholder="Símbolo"
       />
+      <datalist id="symbols">
+        {symbolsList.map(sym => (
+          <option key={sym} value={sym} />
+        ))}
+      </datalist>
       <Chart data={data} signals={signals} />
     </div>
   );


### PR DESCRIPTION
## Summary
- backend: expose `/api/symbols` with list of data files
- frontend: fetch available symbols and show as dropdown list
- handle request errors and trim user input

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68628d3d47a48320a5cfa72fa28fbcaf