### PR TITLE
Add auto data refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ En otra terminal inicia el frontend:
 ```bash
 npm run dev --prefix frontend
 ```
+
+## Actualización automática de datos
+
+La aplicación vuelve a solicitar los datos de la API cada minuto para mantener el gráfico actualizado.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,11 @@ export default function App() {
   useEffect(() => { fetchData(symbol); }, [symbol]);
 
   useEffect(() => {
+    const id = setInterval(() => fetchData(symbol), 60000);
+    return () => clearInterval(id);
+  }, [symbol]);
+
+  useEffect(() => {
     axios.get('/api/symbols')
       .then(res => setSymbolsList(res.data))
       .catch(() => setSymbolsList([]));


### PR DESCRIPTION
## Summary
- refresh symbol data and signals every minute on frontend
- document the auto refresh behaviour in the README

## Testing
- `npm test --prefix backend` *(fails: no test specified)*
- `npm test --prefix frontend` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68628f9a92c4832095b420d591097f23