### PR TITLE
Add dynamic filtering for asset selection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ export default function App() {
   const [data, setData] = useState([]);
   const [signals, setSignals] = useState([]);
   const [symbolsList, setSymbolsList] = useState([]);
+  const filteredSymbols = symbolsList.filter(sym => sym.toLowerCase().includes(symbol));
 
   const fetchData = async (sym) => {
     try {
@@ -14,17 +15,17 @@ export default function App() {
       setData(d.data);
       const s = await axios.get(`/api/signals/${sym}`);
       setSignals(s.data);
-    } catch (err) {
+    } catch {
       try {
         const d = await axios.get(`/api/realtime/${sym}?market=stock`);
         setData(d.data);
         setSignals([]);
-      } catch (e1) {
+      } catch {
         try {
           const d = await axios.get(`/api/realtime/${sym}?market=crypto`);
           setData(d.data);
           setSignals([]);
-        } catch (e2) {
+        } catch {
           setData([]);
           setSignals([]);
         }
@@ -56,7 +57,7 @@ export default function App() {
         placeholder="Símbolo"
       />
       <datalist id="symbols">
-        {symbolsList.map(sym => (
+        {filteredSymbols.map(sym => (
           <option key={sym} value={sym} />
         ))}
       </datalist>


### PR DESCRIPTION
## Summary
- filter symbol suggestions as the user types
- clean up unused catch variables

## Testing
- `npm install --prefix frontend`
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6862b0ffaf488320b692810d39487f4a